### PR TITLE
Fix outdated copyright year (update to 2014)

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright &copy; 2012 Matthieu Aussaguel
+Copyright (C) 2012-2014; Matthieu Aussaguel
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed years to include 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
