### PR TITLE
Inline style reset

### DIFF
--- a/src/wow.coffee
+++ b/src/wow.coffee
@@ -60,6 +60,7 @@ class @WOW
     iteration = box.getAttribute('data-wow-iteration')
 
     box.setAttribute 'style', @customStyle(hidden, duration, delay, iteration)
+    @resetStyle(box, duration, delay, iteration)
 
   customStyle: (hidden, duration, delay, iteration) ->
     style =  if hidden then "
@@ -91,6 +92,21 @@ class @WOW
       " if iteration
 
     style
+
+  # resets applied inline style for the box element
+  resetStyle: (box, duration, delay, iteration) ->
+    defaultTime = 2;
+    if iteration isnt 'infinite'
+      durationTime = if duration then parseInt(duration.split('s')[0], 10) else defaultTime
+      delayTime = if delay then parseInt(delay.split('s')[0], 10) else 0
+      if durationTime and delayTime
+        totalTime = (delayTime + parseInt(iteration, 10)) * 1000
+        callback = @resetStyleCallback(box)
+        setTimeout callback, totalTime
+
+  # reset style callback
+  resetStyleCallback: (box) ->
+    box.setAttribute('style','')   
 
   # fast window.scroll callback
   scrollHandler: =>


### PR DESCRIPTION
After each animation ends, we could remove the inline style applied so that the markup doesn't become too 'polluted'.

![image](https://f.cloud.github.com/assets/3236388/2120284/04284c8e-91aa-11e3-8730-3928c9654a92.png)
