### PR TITLE
bower.json "main"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "Matthieu Aussaguel <matthieu.aussaguel@gmail.com>"
   ],
   "description": "Reveal CSS animation as you scroll down a page.",
-  "main": "wow.js",
+  "main": "dist/wow.js",
   "keywords": [
     "scroll",
     "animation",


### PR DESCRIPTION
File wow.js doesn't exist.
When I install with grunt bower-install task, it want include `/wow.js`, but file doesn't exist, main file is `/dist/wow.js`.
`GET http://localhost:9000/bower_components/WOW/wow.js 404 (Not Found)`

This PR fix it.
