### PR TITLE
IE8 error fix

### DIFF
--- a/dist/wow.js
+++ b/dist/wow.js
@@ -111,7 +111,7 @@
       this.stopped = false;
       this.boxes = (function() {
         var _i, _len, _ref, _results;
-        _ref = this.element.getElementsByClassName(this.config.boxClass);
+        _ref = this.element.querySelectorAll('.' + this.config.boxClass);
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           box = _ref[_i];
@@ -195,7 +195,7 @@
           return;
         }
         element = element.parentNode || element;
-        _ref = element.getElementsByClassName(this.config.boxClass);
+        _ref = element.querySelectorAll('.' + this.config.boxClass);
         _results = [];
         for (_i = 0, _len = _ref.length; _i < _len; _i++) {
           box = _ref[_i];


### PR DESCRIPTION
Replaced getElementsByClassName() with querySelectorAll().
