### PR TITLE
Added scrollContainer property, allowing the user to specify the container to watch for scrolling

### DIFF
--- a/src/wow.coffee
+++ b/src/wow.coffee
@@ -107,10 +107,13 @@ class @WOW
     mobile:       true
     live:         true
     callback:     null
+    scrollContainer: undefined
 
   constructor: (options = {}) ->
     @scrolled = true
     @config   = @util().extend(options, @defaults)
+    if typeof options.scrollContainer is 'string'
+      @config.scrollContainer = document.querySelector(options.scrollContainer)
     # Map of elements to animation names:
     @animationNameCache = new WeakMap()
     @wowEvent = @util().createEvent(@config.boxClass)
@@ -133,7 +136,7 @@ class @WOW
       else
         @applyStyle(box, true) for box in @boxes
     if !@disabled()
-      @util().addEvent window, 'scroll', @scrollHandler
+      @util().addEvent @config.scrollContainer || window, 'scroll', @scrollHandler
       @util().addEvent window, 'resize', @scrollHandler
       @interval = setInterval @scrollCallback, 50
     if @config.live
@@ -147,7 +150,7 @@ class @WOW
   # unbind the scroll event
   stop: ->
     @stopped = true
-    @util().removeEvent window, 'scroll', @scrollHandler
+    @util().removeEvent @config.scrollContainer || window, 'scroll', @scrollHandler
     @util().removeEvent window, 'resize', @scrollHandler
     clearInterval @interval if @interval?
 
@@ -273,7 +276,7 @@ class @WOW
   # check if box is visible
   isVisible: (box) ->
     offset     = box.getAttribute('data-wow-offset') or @config.offset
-    viewTop    = window.pageYOffset
+    viewTop    = (@config.scrollContainer && @config.scrollContainer.scrollTop) || window.pageYOffset
     viewBottom = viewTop + Math.min(@element.clientHeight, @util().innerHeight()) - offset
     top        = @offsetTop(box)
     bottom     = top + box.clientHeight


### PR DESCRIPTION
The issue I was experiencing with WOWjs was when I tried to use it with a polymer [paper-scroll-header-panel] (https://elements.polymer-project.org/elements/paper-scroll-header-panel) which wraps the window inside a scrollable container.  The result is the `windows` scroll event is not fired.  To remedy this, I wanted to specify the container on which to add the scroll listener, rather than default to window, [similar to ScrollMagic](https://github.com/janpaepke/ScrollMagic/blob/master/scrollmagic/uncompressed/ScrollMagic.js#L116)