### PR TITLE
Update For Server side rendering

### DIFF
--- a/src/wow.coffee
+++ b/src/wow.coffee
@@ -193,7 +193,7 @@ class @WOW
     @animate => @customStyle(box, hidden, duration, delay, iteration)
 
   animate: (->
-    if 'requestAnimationFrame' of window
+    if typeof window != 'undefined' and 'requestAnimationFrame' of window
       (callback) ->
         window.requestAnimationFrame callback
     else


### PR DESCRIPTION
This update is necessary as while server-side rendering you do not have 'window' object. Its just a small check that makes it run with an error.