### PR TITLE
Fix HTML5Shiv link

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -12,7 +12,7 @@
     }
   </style>
   <!--[if IE]>
-    <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
   <![endif]-->
 </head>
 


### PR DESCRIPTION
Google Code has closed down so the link no longer works -instead use `https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js` which Bootstrap 3 uses: https://getbootstrap.com/docs/3.4/getting-started/#template