### PR TITLE
Fixed target.className.replace is not a function issue

### DIFF
--- a/dist/wow.js
+++ b/dist/wow.js
@@ -308,7 +308,7 @@
 
     WOW.prototype.show = function(box) {
       this.applyStyle(box);
-      box.className = box.className + " " + this.config.animateClass;
+      box.setAttribute("class", box.getAttribute("class") + " " + this.config.animateClass);
       if (this.config.callback != null) {
         this.config.callback(box);
       }
@@ -359,7 +359,7 @@
       var target;
       if (event.type.toLowerCase().indexOf('animationend') >= 0) {
         target = event.target || event.srcElement;
-        return target.className = target.className.replace(this.config.animateClass, '').trim();
+        target.setAttribute("class", target.getAttribute("class").replace(this.config.animateClass).trim());
       }
     };
 


### PR DESCRIPTION
`resetAnimation` function is throw 
>TypeError: target.className.replace is not a function at WOW.resetAnimation

[Those](https://github.com/matthieua/WOW/issues/185#issuecomment-319997317) get-set helper functions fot the attributes is useful to the issue.